### PR TITLE
QA-Design: Remove footer message

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -17,7 +17,6 @@
           <div class="footer-titles" style="color:#bdbdbd;"><h2><b>Credits </b></h2></div>
           <p class="para-2" style="color:#bdbdbd; font-size:0.9rem; padding-top:0.6rem;">BornPerfect. Africa was created by a transnational team of designers, journalists and developers in partnership with Code for Africa.</p>
         </div>
-        <p class="para-2" style="color:#bdbdbd;font-size:0.85rem;">All images courtesy of the <a href="https://tv.guardian.ng/">Guardian.</a></p>
       </div>
       <div class="col-lg-3 ">
         <div class="col-padding ">


### PR DESCRIPTION
## Description

-Remove "All images are courtesy of the Guardian" message on the footer.


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


## Screenshots

![footermsg](https://user-images.githubusercontent.com/3693563/37210605-67a0e4dc-23ba-11e8-9eb4-5b54979fad79.png)


## Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation